### PR TITLE
Trim down "/boot" excludes so we get to keep /boot/config* and /boot/System.map*

### DIFF
--- a/excludes
+++ b/excludes
@@ -1,7 +1,8 @@
 #lib/modules/*/kernel/fs/cifs
 #lib/modules/*/kernel/fs/nfs
 .docker*
-boot
+boot/initrd*
+boot/vmlinuz*
 dev
 etc/apt
 etc/cron.daily/apt


### PR DESCRIPTION
Fixes #9
