### PR TITLE
Disable "Predictable Network Interface Names"

### DIFF
--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -15,6 +15,9 @@ EOH
 commonAppend='console=ttyS0 console=tty0 boot=live'
 extraAppend='cgroup_enable=memory swapaccount=1'
 
+# explicitly disable "Predictable Network Interface Names" since it causes troubles with our pre-determined /etc/network/interfaces* (and this fix is much easier than implementing our own auto-scan on boot or including network-manager)
+commonAppend+=' net.ifnames=0'
+
 declare -A inits=(
 	[sysvinit]='/lib/sysvinit/init'
 	[systemd]='/lib/systemd/systemd'


### PR DESCRIPTION
In a hilarious bit of irony, we need to disable this "feature" so that our network names are _predictably_ "ethX" (but only actually totally necessary for newer builds of udev -- ie, post-jessie).
